### PR TITLE
Make the build process easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,44 +5,39 @@
 ```bash
 git clone -b linked-examples https://github.com/willcrichton/rust
 cd rust
-./x.py --stage 1 build
-export CUSTOM_RUSTDOC=$(pwd)/build/x86_64-apple-darwin/stage1/bin/rustdoc
+./x.py build
+# replace `apple-darwin` with your current target as appropriate
+rustup toolchain link custom-rustdoc build/x86_64-apple-darwin/stage1
 cd ..
 git clone https://github.com/willcrichton/example-analyzer
-cd example_analyzer
-rustup toolchain install nightly --profile default --component rustc-dev
-rustup override set nightly
+cd example-analyzer
 cargo build
 ```
 
 ## Example
 
-
 ```bash
+# NOTE: the directory you run this from is important since the project uses
+# `rust-toolchain`
+export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
 cd doctest
-export DYLD_LIBRARY_PATH=$HOME/.rustup/toolchains/nightly-x86_64-apple-darwin/lib:$DYLD_LIBRARY_PATH
 ../target/debug/example-analyzer
-cargo clean && cargo doc -vv
-# copy the command within Running `...` and:
-# 1. replace rustdoc with $CUSTOM_RUSTDOC
-# 2. add the flag "--call-locations .call_locations.json" to the end
-# 3. run the command
-open target/doc/doctest/index.html
+cargo +custom-rustdoc rustdoc --open -- --call-locations .call_locations.json
 ```
 
 ## Development
 
-If you change the Rust repo (ie rustdoc) then run:
+If you change the Rust repo (i.e. rustdoc) then run:
 
 ```
-./x.py --stage 1 build
-# also re-run the $CUSTOM_RUSTDOC command
+(cd ../../rust && ./x.py build)
+# also re-run `cargo rustdoc`
 ```
 
 If you change example-analyzer then run:
 
 ```
-cargo build
+(cd .. && cargo build)
 ../target/debug/example-analyzer
-# also the $CUSTOM_RUSTDOC command
+# also re-run `cargo rustdoc`
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ cargo build
 ```bash
 # NOTE: the directory you run this from is important since the project uses
 # `rust-toolchain`
+# On MacOS, use `DYLD_LIBRARY_PATH` instead.
 export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
 cd doctest
 ../target/debug/example-analyzer

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2020-12-09"
+components = ["rustc-dev", "llvm-tools-preview"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2020-12-09"
+channel = "nightly-2020-12-11"
 components = ["rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
Notice I didn't say simpler.

This does a quite a few things:

- Pins a version of nightly using `rust-toolchain`. This avoids
  confusion when rustc changes its API in a later version. When rebasing
  over rust-lang/master, rust-toolchain should also be updated.
- Replaces CUSTOM_RUSTDOC with `rustup toolchain link`, which allows
  determining the sysroot without hardcoding `.rustup/toolchain` in the
  instructions (*not* the binary).
- Replaces 'copy paste what cargo did with additional arguments' with `cargo rustdoc`
- Determines the sysroot in `src/main.rs` with rustup instead of
  hard-coding it. This is an absolute hack, see the comments for details,
  but it's used by clippy and miri so it works in practice.
- Minor changes to the README to distinguish the current directory